### PR TITLE
Added cvg_sim_msgs as dependency for cvg_sim_gazebo_plugins package

### DIFF
--- a/cvg_sim_gazebo_plugins/CMakeLists.txt
+++ b/cvg_sim_gazebo_plugins/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   std_msgs
+  cvg_sim_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -92,7 +93,7 @@ catkin_package(
   reset_plugin 
   hector_gazebo_ros_baro 
   hector_gazebo_quadrotor_simple_controller hector_gazebo_quadrotor_state_controller
- CATKIN_DEPENDS image_transport
+ CATKIN_DEPENDS image_transport cvg_sim_msgs
  DEPENDS system_lib
 )
 

--- a/cvg_sim_gazebo_plugins/package.xml
+++ b/cvg_sim_gazebo_plugins/package.xml
@@ -48,6 +48,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>cvg_sim_msgs</build_depend>
   <run_depend>ardrone_autonomy</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
@@ -56,6 +57,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>cvg_sim_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Dependency is used by the hector_gazebo_ros_baro in the
gazebo_ros_baro.h file but is not included in packages dependencies, so
build fails with `catkin build`. This commit fixes the issue.